### PR TITLE
Add issue-tracking pipeline

### DIFF
--- a/issues/ISSUES-HANDOFF.md
+++ b/issues/ISSUES-HANDOFF.md
@@ -1,0 +1,178 @@
+# Wildlife Resilience — Issue Intake Handoff
+
+## Context
+
+We're tracking issues for the Wildlife Resilience project (website + web app)
+using a **Google Form → Google Sheet → GitHub Issues** pipeline.
+
+- **Google Form** ("Wildlife Resilience: Issues") is the intake point.
+  Reporters pick a category (Text change / Bug-fix / New feature) and fill in
+  the relevant fields. Responses land in a linked Google Sheet with triage
+  columns (Status, Owner, Priority, GitHub Issue URL, etc.).
+
+- **GitHub Issues** is where the work gets tracked alongside the code.
+  The Sheet is the inbox; GitHub is the workbench.
+
+- For now, the Form-to-GitHub step is manual. The structured issue data lives
+  in `issues.json` (same directory as this file). Future batches will follow
+  the same format.
+
+## Current repo state (Feb 2026)
+
+**Diverged branches.** Local `main` has 2 commits not on remote; remote has
+6 commits not local. **Pull/merge before pushing any new work.**
+
+**Big picture.** The repo has significant structural debt: the `docs/` folder
+mixes Quarto source (`.qmd`) with built HTML output, there's a duplicate
+`website/` folder (~150MB), no CI/CD, and the `.gitignore` is missing most
+build artifacts. The plan is to clean this up with GitHub Actions so that
+only source files live in the repo and HTML is built/deployed automatically.
+
+## What's in issues.json
+
+`issues.json` contains **13 issues** in two groups:
+
+**Issues 1–5: Form submissions** (from the Google Form intake, Feb 11 2026)
+- #1 Fix citation formatting on Tab 3 (text, high)
+- #2 Add notes field to Tab 3 / snowline context (note, low)
+- #3 Pop-up metrics crib sheet (feature, low)
+- #4 Metrics selector for cross-scenario comparison (feature, low)
+- #5 Fix "funnction" typo on applications page (text, high)
+
+**Issues 6–13: Repo scan findings** (structural/infra, Feb 12 2026)
+- #6  Remove duplicate `website/` folder (cleanup, high)
+- #7  Set up GitHub Actions for Quarto build + deploy (infra, high)
+- #8  Fix `.gitignore` — exclude build artifacts and large files (infra, high)
+- #9  Restructure `docs/` to separate source from output (infra, high)
+- #10 Delete stale `_site/` folders (cleanup, high)
+- #11 Fix broken link and typo in `foodweb.qmd` (text, high)
+- #12 Remove orphaned pages and stale references (cleanup, low)
+- #13 Resolve diverged local/remote branches (infra, high)
+
+## Task for Claude Code
+
+Read `issues.json` and create all issues in the repo using `gh`.
+
+**Important:** Do this work on a feature branch, not directly on `main`.
+
+### Step 0 — Branch and sync
+
+```bash
+# First, sync main with remote
+git checkout main
+git pull origin main          # resolve divergence here
+
+# Then create a feature branch for the issue-tracking setup
+git checkout -b issues
+```
+
+The `issues/` folder is already in the working tree (untracked). It will
+carry over to the new branch automatically.
+
+### Step 1 — Create labels (idempotent)
+
+The `labels` array in `issues.json` defines the label set. Create them
+first. Use `--force` so reruns don't fail if labels already exist:
+
+```
+jq -r '.labels[] | "\(.name)\t\(.color)\t\(.description)"' issues.json |
+while IFS=$'\t' read -r name color desc; do
+  gh label create "$name" --color "$color" --description "$desc" --force
+done
+```
+
+### Step 2 — Create issues from JSON
+
+Use `jq` to extract each issue and `gh issue create` with `--body-file`
+to avoid heredoc quoting problems:
+
+```
+jq -c '.issues[]' issues.json | while read -r issue; do
+  title=$(echo "$issue" | jq -r '.title')
+  labels=$(echo "$issue" | jq -r '.labels | join(",")')
+  body_file=$(mktemp)
+  echo "$issue" | jq -r '.body' > "$body_file"
+  gh issue create --title "$title" --label "$labels" --body-file "$body_file"
+  rm "$body_file"
+done
+```
+
+The key trick is `--body-file` instead of `--body`. It reads the issue body
+from a temp file, sidestepping all the escaping issues with heredocs, quotes,
+special characters, DOIs, em-dashes, etc.
+
+### Step 3 — Commit and push the issues/ folder
+
+```bash
+git add issues/
+git commit -m "Add issue-tracking pipeline (form intake + 13 issues)"
+git push -u origin issues
+```
+
+### Step 4 — Create GitHub issues from JSON
+
+```
+gh issue list --limit 20
+```
+
+Confirm 13 issues appeared with correct titles, labels, and formatted bodies.
+
+### Step 5 — Open a PR
+
+```bash
+gh pr create --title "Add issue-tracking pipeline" \
+  --body "Adds issues/ folder with:
+- issues.json (13 issues: 5 from form intake, 8 from repo scan)
+- ISSUES-HANDOFF.md (workflow docs)
+- createWildlifeResilienceForm.js (Apps Script reference)"
+```
+
+The GitHub issues exist independently of the branch, so they're visible
+immediately. The PR is just to get the tracking files into `main`.
+
+## Reuse pattern
+
+For future batches:
+
+1. Export new rows from the Google Sheet (or copy-paste into a Cowork chat).
+2. Append to `issues.json` (or create a new `issues-batch-N.json`).
+3. Run the same `jq | gh issue create` loop.
+
+The JSON structure per issue is:
+```json
+{
+  "title": "Short descriptive title",
+  "labels": ["category", "area", "severity"],
+  "body": "Markdown body with \\n for newlines"
+}
+```
+
+## Label taxonomy
+
+| Label | Color | Use for |
+|-------|-------|---------|
+| `text` | green | Text/copy changes |
+| `bug-fix` | red-orange | Bugs |
+| `new-feature` | blue | Feature requests |
+| `note` | lavender | Contextual notes or questions |
+| `website` | yellow | Static site (wildliferesilience.github.io) |
+| `web-app` | peach | Interactive web application |
+| `high` | red | High severity |
+| `low` | light green | Low severity |
+| `infra` | purple | Build, CI/CD, repo structure |
+| `cleanup` | teal | Technical debt and cleanup |
+
+## Suggested execution order
+
+Once issues are created, the recommended order of work is:
+
+1. **Resolve branch divergence** (#13) — unblocks everything
+2. **Fix .gitignore** (#8) — prevents tracking more junk
+3. **Delete stale _site/ folders** (#10) — quick win
+4. **Remove duplicate website/ folder** (#6) — big cleanup
+5. **Set up GitHub Actions** (#7) — enables automated builds
+6. **Restructure docs/** (#9) — depends on GH Actions being in place
+7. **Fix text issues** (#5, #11) — quick content fixes
+8. **Fix citation formatting** (#1) — content fix in web app
+9. **Remove orphaned pages** (#12) — cleanup
+10. **Feature requests** (#2, #3, #4) — longer-term roadmap

--- a/issues/createWildlifeResilienceForm.js
+++ b/issues/createWildlifeResilienceForm.js
@@ -1,0 +1,290 @@
+/**
+ * ============================================================
+ *  Wildlife Resilience: Issues
+ *  Google Form + Linked Sheet Generator
+ * ============================================================
+ *
+ * HOW TO USE
+ * ----------
+ * 1. Go to  https://script.google.com
+ * 2. Click  "+ New project"
+ * 3. Delete any starter code and paste this entire file
+ * 4. Click  Run ▶  (or Run → Run function → createWildlifeResilienceForm)
+ * 5. Approve the permission prompts (Google Forms + Sheets access)
+ * 6. Open  View → Execution log  to find your Form & Sheet URLs
+ *
+ * AFTER RUNNING
+ * -------------
+ * • Open the Form edit URL
+ * • Replace the "Screenshot URL" placeholder field with a real File Upload question
+ *   (Apps Script can't create file-upload items — this is a Google API limitation)
+ * • Preview the form and test all three category paths (Text / Bug-fix / New feature)
+ * • Share the published Form URL with your team
+ */
+
+function createWildlifeResilienceForm() {
+
+  // =============================================
+  //  1.  CREATE THE FORM
+  // =============================================
+  var form = FormApp.create('Wildlife Resilience: Issues');
+
+  form.setDescription(
+    'Report text changes, bugs, or feature requests for the Wildlife Resilience project.\n\n' +
+    'Choose a Category below — you\'ll only see the fields relevant to that issue type.'
+  );
+  form.setConfirmationMessage(
+    'Thank you! Your issue has been logged and will be triaged shortly.'
+  );
+
+
+  // -------------------------------------------------------
+  //  SECTION 1 — Intake  (everyone sees this first)
+  // -------------------------------------------------------
+
+  var categoryItem = form.addListItem();
+  categoryItem.setTitle('Category');
+  categoryItem.setHelpText('What type of issue is this?');
+  categoryItem.setRequired(true);
+  // (choices + navigation are wired up below, after all sections exist)
+
+  form.addListItem()
+    .setTitle('Area')
+    .setHelpText('Which part of the project does this affect?')
+    .setRequired(true)
+    .setChoiceValues(['Website', 'Web App', 'Data', 'Other']);
+
+  form.addTextItem()
+    .setTitle('Page / Tab')
+    .setHelpText('e.g., Tab 3, About, Map, etc.');
+
+
+  // -------------------------------------------------------
+  //  SECTION 2 — Text Change Details  (Category = Text)
+  // -------------------------------------------------------
+
+  var textPage = form.addPageBreakItem();
+  textPage.setTitle('Text Change Details');
+  textPage.setHelpText('Describe the text that needs changing.');
+
+  form.addParagraphTextItem()
+    .setTitle('Current Text')
+    .setHelpText(
+      'The exact text currently on the page that needs to change. ' +
+      'Quote it if possible so we can find it quickly.'
+    );
+
+  form.addParagraphTextItem()
+    .setTitle('Suggested Text')
+    .setHelpText('What the text should say instead.');
+
+  form.addParagraphTextItem()
+    .setTitle('Text Change Notes')
+    .setHelpText(
+      'Why the change is needed — context, tone, accuracy, source reference, etc.'
+    );
+
+
+  // -------------------------------------------------------
+  //  SECTION 3 — Bug Details  (Category = Bug-fix)
+  // -------------------------------------------------------
+
+  var bugPage = form.addPageBreakItem();
+  bugPage.setTitle('Bug Details');
+  bugPage.setHelpText('Describe the bug you encountered.');
+
+  form.addParagraphTextItem()
+    .setTitle('What you expected')
+    .setHelpText('What should have happened?');
+
+  form.addParagraphTextItem()
+    .setTitle('What happened instead')
+    .setHelpText('What actually occurred?');
+
+  form.addParagraphTextItem()
+    .setTitle('Steps to reproduce')
+    .setHelpText('How can someone else trigger this bug? List the steps.');
+
+
+  // -------------------------------------------------------
+  //  SECTION 4 — Feature Request  (Category = New feature)
+  // -------------------------------------------------------
+
+  var featurePage = form.addPageBreakItem();
+  featurePage.setTitle('Feature Request Details');
+  featurePage.setHelpText('Describe the feature you\'d like to see.');
+
+  form.addParagraphTextItem()
+    .setTitle('Feature description')
+    .setHelpText(
+      'Describe the desired feature or behavior. What problem would it solve?'
+    );
+
+
+  // -------------------------------------------------------
+  //  SECTION 5 — Additional Details  (everyone sees this)
+  // -------------------------------------------------------
+
+  var commonPage = form.addPageBreakItem();
+  commonPage.setTitle('Additional Details');
+
+  form.addListItem()
+    .setTitle('Severity')
+    .setHelpText('How serious is this issue?')
+    .setRequired(true)
+    .setChoiceValues(['Low', 'Medium', 'High', 'Blocking']);
+
+  form.addTextItem()
+    .setTitle('Browser / OS')
+    .setHelpText('e.g., Chrome / Mac, Safari / iOS');
+
+  form.addTextItem()
+    .setTitle('Link')
+    .setHelpText('Page URL if relevant');
+
+  // NOTE: Google Apps Script cannot create File Upload items.
+  // This placeholder text field should be manually replaced in the Form editor.
+  form.addTextItem()
+    .setTitle('Screenshot URL  — REPLACE with File Upload in Form editor')
+    .setHelpText(
+      'Paste a link to a screenshot (Google Drive, Imgur, etc.).\n' +
+      'TO-DO for form admin: replace this text field with a File Upload question.'
+    );
+
+  form.addTextItem()
+    .setTitle('Reporter name')
+    .setHelpText('Optional');
+
+
+  // -------------------------------------------------------
+  //  CONDITIONAL NAVIGATION
+  // -------------------------------------------------------
+  //
+  //  Category = Text        → textPage     → commonPage
+  //  Category = Bug-fix     → bugPage      → commonPage
+  //  Category = New feature → featurePage  → commonPage
+  //
+  //  setGoToPage on a PageBreakItem controls what happens when
+  //  the PREVIOUS section completes and reaches this break via
+  //  sequential flow.  It does NOT affect users who navigate
+  //  to this break via choice navigation.
+
+  categoryItem.setChoices([
+    categoryItem.createChoice('Text',        textPage),
+    categoryItem.createChoice('Bug-fix',     bugPage),
+    categoryItem.createChoice('New feature', featurePage)
+  ]);
+
+  // Skip forward to commonPage when arriving via sequential flow
+  bugPage.setGoToPage(commonPage);
+  featurePage.setGoToPage(commonPage);
+
+
+  // =============================================
+  //  2.  CREATE & LINK THE RESPONSE SPREADSHEET
+  // =============================================
+
+  var ss = SpreadsheetApp.create('Wildlife Resilience: Issues (Responses)');
+  form.setDestination(FormApp.DestinationType.SPREADSHEET, ss.getId());
+
+  // Give Google a moment to generate the "Form Responses 1" sheet
+  SpreadsheetApp.flush();
+  Utilities.sleep(3000);
+
+  // Re-open to pick up the newly created response sheet
+  ss = SpreadsheetApp.openById(ss.getId());
+
+  var responseSheet = null;
+  var sheets = ss.getSheets();
+  for (var i = 0; i < sheets.length; i++) {
+    if (sheets[i].getName().indexOf('Form Responses') !== -1) {
+      responseSheet = sheets[i];
+      break;
+    }
+  }
+  if (!responseSheet) {
+    responseSheet = sheets[0]; // fallback
+  }
+
+
+  // =============================================
+  //  3.  ADD TRIAGE COLUMNS  (not in the form)
+  // =============================================
+
+  var lastCol = responseSheet.getLastColumn();
+  if (lastCol < 1) lastCol = 16;
+  var triageStart = lastCol + 1;
+
+  var triageHeaders = [
+    'Status',            // dropdown: New | Triaged | In progress | Blocked | Done | Won't fix
+    'Owner',             // free text
+    'Priority',          // dropdown: P0 | P1 | P2
+    'GitHub Issue URL',  // free text (link)
+    'GH Issue #',        // free text
+    'Release/Version',   // free text
+    'Notes'              // free text
+  ];
+
+  // Write headers
+  var headerRange = responseSheet.getRange(1, triageStart, 1, triageHeaders.length);
+  headerRange.setValues([triageHeaders]);
+  headerRange.setFontWeight('bold');
+  headerRange.setBackground('#E8EAF6');
+
+  // Data validation: Status
+  var statusRule = SpreadsheetApp.newDataValidation()
+    .requireValueInList([
+      'New', 'Triaged', 'In progress', 'Blocked', 'Done', "Won't fix"
+    ])
+    .setAllowInvalid(false)
+    .build();
+  responseSheet.getRange(2, triageStart, 500, 1).setDataValidation(statusRule);
+
+  // Data validation: Priority
+  var priorityCol = triageStart + 2;
+  var priorityRule = SpreadsheetApp.newDataValidation()
+    .requireValueInList(['P0', 'P1', 'P2'])
+    .setAllowInvalid(false)
+    .build();
+  responseSheet.getRange(2, priorityCol, 500, 1).setDataValidation(priorityRule);
+
+  // Freeze header row
+  responseSheet.setFrozenRows(1);
+
+  // Remove empty default "Sheet1" if present
+  try {
+    for (var j = 0; j < sheets.length; j++) {
+      if (sheets[j].getName() === 'Sheet1' && sheets[j].getLastRow() <= 1) {
+        ss.deleteSheet(sheets[j]);
+        break;
+      }
+    }
+  } catch (e) {
+    // Can't delete the only sheet — not a problem
+  }
+
+
+  // =============================================
+  //  4.  LOG RESULTS
+  // =============================================
+
+  var formUrl  = form.getPublishedUrl();
+  var editUrl  = form.getEditUrl();
+  var sheetUrl = ss.getUrl();
+
+  Logger.log('');
+  Logger.log('==========================================');
+  Logger.log('  WILDLIFE RESILIENCE: ISSUES — COMPLETE');
+  Logger.log('==========================================');
+  Logger.log('');
+  Logger.log('Form (share this):   ' + formUrl);
+  Logger.log('Form (edit):         ' + editUrl);
+  Logger.log('Sheet (tracker):     ' + sheetUrl);
+  Logger.log('');
+  Logger.log('NEXT STEPS:');
+  Logger.log('1. Open the Form edit URL');
+  Logger.log('2. Replace "Screenshot URL" text field with a File Upload question');
+  Logger.log('3. Preview the form — test Text, Bug-fix, and New feature paths');
+  Logger.log('4. Share the published Form URL with your team');
+  Logger.log('');
+}

--- a/issues/issues.json
+++ b/issues/issues.json
@@ -1,0 +1,81 @@
+{
+  "labels": [
+    { "name": "text", "color": "0E8A16", "description": "Text/copy change" },
+    { "name": "note", "color": "D4C5F9", "description": "Contextual note or question" },
+    { "name": "new-feature", "color": "1D76DB", "description": "New feature request" },
+    { "name": "bug-fix", "color": "D93F0B", "description": "Bug fix" },
+    { "name": "website", "color": "FBCA04", "description": "Affects the static website" },
+    { "name": "web-app", "color": "F9D0C4", "description": "Affects the web app" },
+    { "name": "high", "color": "B60205", "description": "High severity" },
+    { "name": "low", "color": "C2E0C6", "description": "Low severity" },
+    { "name": "infra", "color": "5319E7", "description": "Build, CI/CD, repo structure" },
+    { "name": "cleanup", "color": "BFDADC", "description": "Technical debt and cleanup" }
+  ],
+  "issues": [
+    {
+      "title": "Fix citation formatting for LANDIS and food web references on Tab 3",
+      "labels": ["text", "web-app", "high"],
+      "body": "## Text change\n\n**Area:** Web App — Tab 3\n\n**Current text:**\n> LANDIS Scenarios: Maxwell et al. 2022. Assessing the effectiveness of landscape-scale forest adaptation actions to improve resilience under projected climate change. Food web data outputs: Wilcox, et. al. in prep. Climate and management impacts on community-level processes.\n\n**Suggested text:**\n> Maxwell, C. J., Scheller, R. M., Wilson, K. N., & Manley, P. N. (2022). Assessing the effectiveness of landscape-scale forest adaptation actions to improve resilience under projected climate change. *Frontiers in Forests and Global Change*, 5, 740869. https://doi.org/10.3389/ffgc.2022.740869\n>\n> Wilcox, R. C., D. D. Kapan, A. M. White, P. N. Manley, J. P. Dumbacher, B. L. Estes, and P. D. Roopnarine. (In review). Ecological modeling of temperate forest community food webs with implications for conservation. Submitted to *Ecosphere*.\n\n**Why:** Use proper citation data and formatting (full author lists, journal name, DOI).\n\n**Severity:** High\n**Reporter:** Durrell"
+    },
+    {
+      "title": "Add notes field to Tab 3; consider snowline change context",
+      "labels": ["note", "web-app", "low"],
+      "body": "## Note\n\n**Area:** Web App — Tab 3\n\nOn Tab 3 we show the map with the snowline — will it change in 80 years? We need a way to surface contextual notes like this for users.\n\nConsider adding a notes or annotation field on Tab 3 where we can provide interpretive context alongside the map data.\n\n**Severity:** Low\n**Reporter:** Durrell"
+    },
+    {
+      "title": "Add pop-up crib sheet for metrics definitions",
+      "labels": ["new-feature", "low"],
+      "body": "## Feature request\n\n**Area:** Other — Tabs 1–3, or possibly a dedicated new page\n\nA readily available pop-up crib sheet on the metrics. Could be a replacement for the metrics page, but ideally we want to be able to see it hovering over the browser (or app) to refer to while viewing other tabs.\n\n**Use case:** Users need quick reference to metric definitions without navigating away from the data they're looking at.\n\n**Severity:** Low\n**Reporter:** Durrell"
+    },
+    {
+      "title": "Add metrics selector on Tab 3 for cross-scenario comparison",
+      "labels": ["new-feature", "web-app", "low"],
+      "body": "## Feature request\n\n**Area:** Web App — Tab 3 (mostly), possibly Tab 2\n\nA metrics selector on Tab 3 so we can view the SAME metrics across different scenarios. This would allow direct comparison of how a given metric changes under different management or climate scenarios.\n\n**Note:** This adds another layer of UI complexity. Should await the publication of the 500ha food web paper before implementing.\n\n**Severity:** Low\n**Reporter:** Durrell"
+    },
+    {
+      "title": "Fix typo: \"funnction\" → \"function\" on applications page",
+      "labels": ["text", "website", "high"],
+      "body": "## Text change\n\n**Area:** Website\n**Link:** https://wildliferesilience.github.io/wildliferesilience/applications.html\n\n**Current text:**\n> How does the composition, structure, and funnction of mixed conifer and red fir forest wildlife communities differ?\n\n**Suggested text:**\n> How does the composition, structure, and function of mixed conifer and red fir forest wildlife communities differ?\n\n**Why:** Spelling fix (\"funnction\" → \"function\").\n\n**Severity:** High\n**Reporter:** Durrell"
+    },
+    {
+      "title": "Remove duplicate website/ folder",
+      "labels": ["cleanup", "high"],
+      "body": "## Cleanup\n\nThe `website/` folder is a near-exact duplicate of `docs/` — same `.qmd` source files, same images, same `_quarto.yml` (which itself points `output-dir: ../docs`). This adds ~150MB of redundancy to the repo.\n\n**Action:**\n- Verify nothing in `website/` is unique (diff against `docs/`)\n- Delete `website/` entirely\n- Keep `docs/` as the single source of truth\n\n**Source:** Repo scan, Feb 2026"
+    },
+    {
+      "title": "Set up GitHub Actions for Quarto build and deploy",
+      "labels": ["infra", "new-feature", "high"],
+      "body": "## Infrastructure\n\nNo CI/CD exists — no `.github/workflows/` directory at all. The site is currently built locally and HTML is committed directly to the repo.\n\n**Proposed workflow:**\n1. On push to `main`: Quarto renders `.qmd` → HTML\n2. Deploy to GitHub Pages via `actions/deploy-pages`\n3. Stop committing built HTML to the repo\n\n**Benefits:**\n- `.qmd` source files are the only thing in version control\n- No more mixed source/output in `docs/`\n- Consistent builds (no \"works on my machine\")\n- Enables branch previews later\n\n**Dependencies:** Resolve the docs/ folder structure first (see related issue).\n\n**Source:** Repo scan, Feb 2026"
+    },
+    {
+      "title": "Fix .gitignore — exclude build artifacts and large files",
+      "labels": ["infra", "high"],
+      "body": "## Infrastructure\n\nThe current `.gitignore` is missing critical exclusions. All HTML output, Quarto cache, and large binary files are tracked in git.\n\n**Missing exclusions:**\n```\n# Quarto build output\n*.html\n_site/\n_cache/\n.quarto/\n*_files/\n_freeze/\n\n# Large binary files (consider Git LFS)\n*.svg\n*.tif\n*.tiff\n\n# Generated exports\ndocs/converted/\n```\n\n**Currently tracked that shouldn't be:**\n- 13 `.html` files in `docs/` (build output)\n- 2 stale `_site/` folders\n- `.quarto/` cache directories\n- `PlantPollinator_Picture_Collage.svg` (32MB)\n- `LTB_map_RFR_SMC.svg` (27MB)\n- `TCSI_boundary.tif` (66MB)\n- `.RData` (1.3MB) at repo root\n- 10+ `.DS_Store` files\n\n**Note:** After updating `.gitignore`, run `git rm -r --cached .` and recommit to stop tracking these files. Consider Git LFS for large assets that do need to be in the repo.\n\n**Source:** Repo scan, Feb 2026"
+    },
+    {
+      "title": "Restructure docs/ to separate Quarto source from build output",
+      "labels": ["infra", "high"],
+      "body": "## Infrastructure\n\nThe `docs/` folder currently contains both `.qmd` source files and their `.html` output side-by-side. This is because `_quarto.yml` sets `output-dir: ../docs`, which outputs into the same directory as the sources.\n\n**Current state:**\n```\ndocs/\n  about.qmd       ← source\n  about.html      ← output\n  about_files/    ← output\n  _site/          ← stale output\n  _quarto.yml     ← config\n  ...\n```\n\n**Proposed structure (with GH Actions):**\n```\ndocs/              ← source only (.qmd, _quarto.yml, images, input data)\n  _quarto.yml\n  about.qmd\n  images/\n  input/\n```\nHTML output is built by CI and deployed directly — never committed.\n\n**Blocked by:** GitHub Actions setup (see related issue).\n\n**Source:** Repo scan, Feb 2026"
+    },
+    {
+      "title": "Delete stale _site/ folders",
+      "labels": ["cleanup", "high"],
+      "body": "## Cleanup\n\nTwo stale `_site/` directories exist with outdated builds from July 2023:\n- `docs/_site/` (7.6MB)\n- `website/_site/` (7.6MB)\n\nThese contain orphaned pages (`research_highlights.html`, `study_site.html`) that aren't in the current navbar and serve no purpose.\n\n**Action:** Delete both `_site/` directories.\n\n**Source:** Repo scan, Feb 2026"
+    },
+    {
+      "title": "Fix broken link and typo in foodweb.qmd",
+      "labels": ["text", "website", "high"],
+      "body": "## Text change\n\n**Area:** Website — `docs/foodweb.qmd`\n\n**Issue 1 — Missing protocol on link:**\n```markdown\n[*Puma concolor* - Moutain lion](phylopic.org/images/...)\n```\nShould be:\n```markdown\n[*Puma concolor* - Mountain lion](https://www.phylopic.org/images/...)\n```\n\n**Issue 2 — Typo:** \"Moutain\" → \"Mountain\"\n\n**Source:** Repo scan, Feb 2026"
+    },
+    {
+      "title": "Remove orphaned pages and stale references",
+      "labels": ["cleanup", "website", "low"],
+      "body": "## Cleanup\n\n**Area:** Website — `docs/`\n\nSeveral files exist that aren't referenced in the navbar or are remnants of old structure:\n\n- `biodiversityII.qmd` / `biodiversityII.html` — not in navbar\n- `footer.qmd` — 16 bytes, utility file with no page content\n- `study_area.rmarkdown` — legacy R Markdown format, superseded by `central_sierras.qmd`\n- `central_sierras.rmarkdown` — legacy format alongside the `.qmd` version\n- `test.py` — old test file (~2KB)\n- `docs/exportdocx.sh` + `docs/converted/` — docx export pipeline (12MB of .docx files in repo)\n- Commented-out link to non-existent `study_area.qmd` in `index.qmd`\n\n**Action:** Review each, delete what's no longer needed, update any stale references.\n\n**Source:** Repo scan, Feb 2026"
+    },
+    {
+      "title": "Resolve diverged local and remote branches",
+      "labels": ["infra", "high"],
+      "body": "## Infrastructure\n\n`git status` shows local `main` and `origin/main` have diverged:\n- 2 local commits ahead\n- 6 remote commits ahead\n\n**Local-only commits:**\n```\n7854598 Merge branch 'main' of https://github.com/wildliferesilience/wildliferesilience\n368d230 updated project ID\n```\n\n**Remote-only commits:**\n```\ndb460cb Updated web app iframe height\n30a9fcc Merge branch 'main'\nb55132e Updated web app iframe height\n6585751 Delete CNAME\nc9c3d84 Create CNAME\n687e2c3 Updated Web App tab iframe with new wildliferesilience shinyapps.io app\n```\n\n**Action:** Pull and merge (or rebase) before pushing any new work.\n\n**Source:** Repo scan, Feb 2026"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `issues/` folder with structured issue-tracking pipeline files
- `issues.json` — 13 issues (5 from Google Form intake, 8 from repo scan)
- `ISSUES-HANDOFF.md` — workflow documentation for the Form → Sheet → GitHub pipeline
- `createWildlifeResilienceForm.js` — Apps Script reference for the Google Form
- 10 custom labels created (text, note, new-feature, bug-fix, website, web-app, high, low, infra, cleanup)
- 13 GitHub issues created (#53–#65) with proper labels and formatted bodies

## Test plan
- [x] Labels created via `gh label create --force`
- [x] 13 issues created and verified via `gh issue list`
- [x] Issue titles, labels, and bodies match `issues.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)